### PR TITLE
Omit plaintext passwords from console logging ApiHelper.ts

### DIFF
--- a/src/helpers/ApiHelper.ts
+++ b/src/helpers/ApiHelper.ts
@@ -90,7 +90,9 @@ export class ApiHelper {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data)
     };
-    console.log(config.url + path, requestOptions);
+    if (!config.url.includes("/login")) {
+      console.log(config.url + path, requestOptions);
+    }
     return await this.fetchWithErrorHandling(config.url + path, requestOptions);
   }
 


### PR DESCRIPTION
Can be extended to only enable in dev stack, but noticed my password in plaintext in the console on prod.
I'm sure this can be done in a better way. Just flagging here for now.