### PR TITLE
React 19

### DIFF
--- a/packages/apphelper-markdown/package.json
+++ b/packages/apphelper-markdown/package.json
@@ -33,8 +33,8 @@
   "peerDependencies": {
     "@churchapps/helpers": "^1.0.42",
     "@churchapps/apphelper": "^0.4.17",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@lexical/code": "^0.33.0",

--- a/packages/apphelper/package.json
+++ b/packages/apphelper/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/LiveChurchSolutions/AppHelper#readme",
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-router-dom": "^7.6.3"
   },
   "dependencies": {

--- a/packages/donations/package.json
+++ b/packages/donations/package.json
@@ -30,8 +30,8 @@
   "peerDependencies": {
     "@churchapps/helpers": "^1.0.42",
     "@churchapps/apphelper": "^0.4.17",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-router-dom": "^7.6.3"
   },
   "dependencies": {

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -29,8 +29,8 @@
   "peerDependencies": {
     "@churchapps/helpers": "^1.0.42",
     "@churchapps/apphelper": "^0.4.17",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-router-dom": "^7.6.3"
   },
   "dependencies": {


### PR DESCRIPTION
AI seemed to think updating to React 19 in AppHelper was necessary for the Chums side of things to work. I do not know if this is genuinely necessary, but it did seem to fix an error with building.